### PR TITLE
Only show UTC time on Meetings page

### DIFF
--- a/docs/discord/meetings.md
+++ b/docs/discord/meetings.md
@@ -14,10 +14,10 @@ Regular meetings are essential to RaidGuild’s operations, keeping members alig
 
 | **Meeting Name**         | **Who Attends?**                               | **Purpose**                          | **Schedule**                                              |
 |--------------------------|-----------------------------------------------|--------------------------------------|-----------------------------------------------------------|
-| **Raider Roundup**       | Full members and past cohort members           | Raid coordination and management     | Weekly, Tuesdays<br />1pm EDT / 10am PST / 6pm UTC          |
-| **Round Table**          | Full members only                              | Open forum for coordination          | Weekly, Thursdays<br />9am PST / 11am EDT / 4pm UTC         |
-| **Token Talk**           | Full members and past cohort members           | Discuss the $RAID token and usage    | Weekly, Thursdays<br />2:30pm PST / 5:30pm EST / 10:30pm UTC|
-| **Cohort Community Call**| Open to past cohort members                    | Community support and membership     | Weekly, Wednesdays<br />11am PST / 2pm EST / 7pm UTC        |
+| **Raider Roundup**       | Full members and past cohort members           | Raid coordination and management     | Weekly, Tuesdays<br />6pm UTC          |
+| **Round Table**          | Full members only                              | Open forum for coordination          | Weekly, Thursdays<br />4pm UTC         |
+| **Token Talk**           | Full members and past cohort members           | Discuss the $RAID token and usage    | Weekly, Thursdays<br />10:30pm UTC|
+| **Cohort Community Call**| Open to past cohort members                    | Community support and membership     | Weekly, Wednesdays<br />7pm UTC        |
 
 ---
 
@@ -27,7 +27,7 @@ Two key roles keep our meetings organized and productive:
 
 - **Stewards**: Stewards look after particular aspects of Guild knowledge. They are often tapped to provide updates on their realm, which provides important structure for our knowledge sharing.
   
-- **Jesters**: Jesters serve as emcees, leading discussions and keeping conversations engaging. The Council of Jesters rotates this role to keep each meeting dynamic and focused.
+- **Jesters**: Jesters serve as emcees, leading discussions and keeping conversations engaging. The Sync Steward rotates this role to keep each meeting dynamic and focused.
 
 Together, Stewards and Jesters help maintain a productive meeting environment, ensuring that conversations stay on track and goals are achieved.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated community meeting schedules to reflect a unified UTC timing for all events.
  - Revised the description of meeting roles, clarifying that the emcee rotation is managed by the Sync Steward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->