### PR TITLE
Replace Collab.Land with Guild.XYZ on Bots page

### DIFF
--- a/docs/discord/bots.md
+++ b/docs/discord/bots.md
@@ -10,18 +10,16 @@ Within the Guild, we rely on several bots to streamline tasks, coordinate events
 
 ---
 
-### **Collab.Land**
+### **Guild.XYZ**
 
-The [Collab.Land](https://collab.land/) bot grants roles and permissions by verifying your membership using your wallet. Guild members and Apprentices can unlock additional server access by linking their Discord account to their wallet.
+The [Guild.XYZ](https://guild.xyz/) bot grants roles and permissions by verifying your membership using your wallet. Guild members and Apprentices can unlock additional server access by linking their Discord account to their wallet.
 
-#### Steps to Verify with Collab.Land:
+#### Steps to Verify with Guild.XYZ:
 
 1. Unlock your wallet and set it to the Gnosis Chain network.
-2. Head to **#🔓│verify-assets** and click **Let’s Go!**
-3. Follow the bot’s instructions to connect your wallet.
-4. On the Collab.Land website, select Raid Guild and click **Verify**.
-5. Sign any prompted transaction in your wallet.
-6. Return to Discord and await confirmation of your server roles.
+2. Head to **#🔓│validate-membership** in our Discord server and click **Verify your member shares**
+3. Follow the linked page's instructions for how to connect your wallet and meet requirements.
+4. After completing the requirements on Guild.XYZ's page, return to Discord and click **Join RaidGuild**.
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Discord Bots documentation to reflect the rebranding from Collab.Land to Guild.XYZ.
  - Revised verification instructions, including updated guidance for wallet connection and membership validation. The new steps now direct users to the "#🔓│validate-membership" channel and conclude the process by clicking "Join RaidGuild."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->