### PR TITLE
release: staging -> production

### DIFF
--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -135,7 +135,7 @@ To claim the _Handbook Steward_ role a member will need to claim two other roles
 
 The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. The Sync Steward can optionally delegate hosting and scribing responsibilities to a Jester and/or Scribe.
 
-Sync Steward Auxiliary Roles
+#### Sync Steward Auxiliary Roles
 
 - **_Jester_** - _Sync Jesters_ are responsible for emceeing the synchronous gatherings. They can leverage known topics and field topics that are relevant to current goals of the Guild.
 - **_Scribe_** - _Sync Scribes_ are responsible for recording meeting notes and sharing insights with the wider Guild

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -65,7 +65,7 @@ Current services handled by _Infrastructure Maestro_:
 - [Guild.xyz](https://guild.xyz/raidguild)
 - [DigitalOcean](https://www.digitalocean.com/)
 
-If you need to deploy new infra, reach out to one of the IM for updating.
+If you need to deploy new infra, reach out to one of the IMs to get it updated.
 
 :::info[Latest budget]
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -135,25 +135,11 @@ To claim the _Handbook Steward_ role a member will need to claim two other roles
 
 The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. The Sync Steward can optionally delegate hosting and scribing responsibilities to a Jester and/or Scribe.
 
-Sync Guild Roles
+Sync Steward Auxiliary Roles
 
 - **_Sync Steward_** - _Sync Steward_ coordinates with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
 - **_Jester_** - _Sync Jesters_ are responsible for emceeing the synchronous gatherings. They can leverage known topics and field topics that are relevant to current goals of the Guild.
 - **_Scribe_** - _Sync Scribes_ are responsible for recording meeting notes and sharing insights with the wider Guild
-
-#### Sync Steward
-
-The Sync Steward is responsible for coordinating with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
-
-The Steward requests a regular budget where needed to ensure the members are incentivized to participate. The Steward will document goals for the current budget and provide regular updates throughout the duration of the epoch.
-
-:::info[Latest budget]
-
-~3k per quarter
-
-:::
-
-_It's expected that a majority of the budget is allocated to completing the actual execution/implementation tasks. Roughly, up to a third of the budget should be used for Steward coordination responsibilities and planning._
 
 #### Claiming a Sync Guild role
 
@@ -168,7 +154,7 @@ To claim a Sync Guild role a member will need to claim two other roles:
 
 ### Participation Steward - Tracker of Member Activeness
 
-The [_Participation Steward ](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.1.6) is responsible for keeping an organized and public table of all active participants; this includes what they participated in, what their member address is, and how many shares they will be rewarded with.
+The [_Participation Steward_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.1.6) is responsible for keeping an organized and public table of all active participants; this includes what they participated in, what their member address is, and how many shares they will be rewarded with.
 
 See the original role creation proposal [here](https://github.com/raid-guild/RIPs/issues/213), and the latest amendment [here](https://github.com/raid-guild/RIPs/issues/227).
 
@@ -182,7 +168,7 @@ _It's expected that a majority of the budget is allocated to completing the actu
 
 ### Angry Dwarf - Keeper of the Treasury
 
-The [_Angry Dwarf ](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.6) is responsible for creating quarterly accounting reports, ensuring cleric SOPs are followed, and implementing sensible portfolio management.
+The [_Angry Dwarf_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.6) is responsible for creating quarterly accounting reports, ensuring cleric SOPs are followed, and implementing sensible portfolio management.
 
 :::info[Latest budget]
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -61,12 +61,15 @@ Current services handled by _Infrastructure Maestro_:
 - [TheGraph](https://thegraph.com)
 - [Railway](https://railway.app)
 - [Heroku](https://heroku.com)
+- [Google Cloud](https://cloud.google.com/)
+- [Guild.xyz](https://guild.xyz/raidguild)
+- [DigitalOcean](https://www.digitalocean.com/)
 
 If you need to deploy new infra, reach out to one of the IM for updating.
 
 :::info[Latest budget]
 
-~2k per year
+~$2.5 per year
 
 :::
 
@@ -90,7 +93,7 @@ The _Brand Steward_ requests a regular budget where needed to ensure the project
 
 :::info[Latest budget]
 
-~6k per year
+~1.6k per year
 
 :::
 
@@ -113,7 +116,7 @@ The _Handbook Steward_ requests a regular budget where needed to ensure the proj
 
 :::info[Latest budget]
 
-~6k per year
+~1.6k per year
 
 :::
 
@@ -128,19 +131,19 @@ To claim the _Handbook Steward_ role a member will need to claim two other roles
 3. The _Handbook Steward_ role is appointed by [_Ganggang_](#ganggang---quality-assurance-delegates) via offchain consensus
 4. Claim the _Handbook Steward_ role
 
-### Sync Guild - Coordinating the synchronous layer
+### Sync Steward - Coordinating the synchronous layer
 
-The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. As a part of the Sync Guild there are 3 roles activated to spread the burden for this role across a small group.
+The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. The Sync Steward can optionally delegate hosting and scribing responsibilities to a Jester and/or Scribe.
 
 Sync Guild Roles
 
-- **_Sync Steward_** - _Sync Steward_ coordinates with other members of the Sync Guild and wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
+- **_Sync Steward_** - _Sync Steward_ coordinates with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
 - **_Jester_** - _Sync Jesters_ are responsible for emceeing the synchronous gatherings. They can leverage known topics and field topics that are relevant to current goals of the Guild.
 - **_Scribe_** - _Sync Scribes_ are responsible for recording meeting notes and sharing insights with the wider Guild
 
 #### Sync Steward
 
-The Sync Steward is responsible for coordinating with other members of the Sync Guild and wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
+The Sync Steward is responsible for coordinating with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
 
 The Steward requests a regular budget where needed to ensure the members are incentivized to participate. The Steward will document goals for the current budget and provide regular updates throughout the duration of the epoch.
 
@@ -162,6 +165,32 @@ To claim a Sync Guild role a member will need to claim two other roles:
    - Claim the _Sync Steward_ role
 4. The _Jester_ and _Scribe_ roles are appointed by the _Sync Steward_ role via offchain consensus
    - Claim the _Jester_ or _Scribe_ role
+
+### Participation Steward - Tracker of Member Activeness
+
+The [_Participation Steward ](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.1.6) is responsible for keeping an organized and public table of all active participants; this includes what they participated in, what their member address is, and how many shares they will be rewarded with.
+
+See the original role creation proposal [here](https://github.com/raid-guild/RIPs/issues/213), and the latest amendment [here](https://github.com/raid-guild/RIPs/issues/227).
+
+:::info[Latest budget]
+
+~3k per year
+
+:::
+
+_It's expected that a majority of the budget is allocated to completing the actual execution/implementation tasks._
+
+### Angry Dwarf - Keeper of the Treasury
+
+The [_Angry Dwarf ](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.6) is responsible for creating quarterly accounting reports, ensuring cleric SOPs are followed, and implementing sensible portfolio management.
+
+:::info[Latest budget]
+
+~2k per year
+
+:::
+
+_It's expected that a majority of the budget is allocated to completing the actual execution/implementation tasks._
 
 ## Roles Chart (Hats Tree)
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -69,7 +69,7 @@ If you need to deploy new infra, reach out to one of the IM for updating.
 
 :::info[Latest budget]
 
-~$2.5 per year
+~2.5k per year
 
 :::
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -133,7 +133,7 @@ To claim the _Handbook Steward_ role a member will need to claim two other roles
 
 ### Sync Steward - Coordinating the synchronous layer
 
-The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. The Sync Steward can optionally delegate hosting and scribing responsibilities to a Jester and/or Scribe.
+The [_Sync Steward_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is responsible for coordinating the Guild's [synchronous meetings](../discord/meetings) so they are efficient and useful to members and attendees. The Sync Steward can optionally delegate hosting and scribing responsibilities to a Jester and/or Scribe.
 
 #### Sync Steward Auxiliary Roles
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -137,9 +137,20 @@ The [_Sync Guild_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.3) is 
 
 Sync Steward Auxiliary Roles
 
-- **_Sync Steward_** - _Sync Steward_ coordinates with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
 - **_Jester_** - _Sync Jesters_ are responsible for emceeing the synchronous gatherings. They can leverage known topics and field topics that are relevant to current goals of the Guild.
 - **_Scribe_** - _Sync Scribes_ are responsible for recording meeting notes and sharing insights with the wider Guild
+
+The Sync Steward is responsible for coordinating with the wider Guild to make sure topics to be discussed are relevant. They also encourage members to pick up the other roles for meetings in which they'll be in attendance.
+
+The Steward requests a regular budget where needed to ensure the members are incentivized to participate. The Steward will document goals for the current budget and provide regular updates throughout the duration of the epoch.
+
+:::info[Latest budget]
+
+~3k per quarter
+
+:::
+
+_It's expected that a majority of the budget is allocated to completing the actual execution/implementation tasks. Roughly, up to a third of the budget should be used for Steward coordination responsibilities and planning._
 
 #### Claiming a Sync Guild role
 

--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -152,9 +152,9 @@ The Steward requests a regular budget where needed to ensure the members are inc
 
 _It's expected that a majority of the budget is allocated to completing the actual execution/implementation tasks. Roughly, up to a third of the budget should be used for Steward coordination responsibilities and planning._
 
-#### Claiming a Sync Guild role
+#### Claiming a Sync Steward, Jester, or Scribe role
 
-To claim a Sync Guild role a member will need to claim two other roles:
+To claim a _Sync Steward_, _Jester_, or _Scribe_ role, a member will first need to claim these two prerequisite roles:
 
 1. [_RaidGuild Member_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.1)
 2. [_Tavern Keeper (Community)_](https://app.hatsprotocol.xyz/trees/100/92?hatId=92.1.5.2)


### PR DESCRIPTION
This pull request updates the `dao-roles.md` documentation to reflect new infrastructure services, adjusts budget allocations for several roles, clarifies the responsibilities and structure of the Sync Steward and auxiliary roles, and introduces two new roles: Participation Steward and Angry Dwarf. These changes improve accuracy and transparency regarding responsibilities and budgets within the DAO.

**Infrastructure and Budget Updates:**
- Added `Google Cloud`, `Guild.xyz`, and `DigitalOcean` to the list of infrastructure services managed by the Infrastructure Maestro, and updated the annual budget estimate from ~$2k to ~$2.5k.
- Reduced the annual budgets for both the Brand Steward and Handbook Steward roles from ~$6k to ~$1.6k. [[1]](diffhunk://#diff-7bfe561f75fd164de5c6c13339b4de1297b593e4081a1869f586a3433322d5f6L93-R96) [[2]](diffhunk://#diff-7bfe561f75fd164de5c6c13339b4de1297b593e4081a1869f586a3433322d5f6L116-R119)

**Role Structure and Clarity:**
- Renamed "Sync Guild" section to "Sync Steward" and clarified that the Sync Steward can delegate hosting and scribing to Jester and Scribe roles. Updated descriptions to better define responsibilities and auxiliary roles.

**New Roles Added:**
- Introduced the Participation Steward role, responsible for tracking member activeness, including a public participation table and budget details.
- Added the Angry Dwarf role, responsible for treasury management and accounting, with a defined annual budget.