### PR TITLE
chore: revise budget estimate for DAO roles

### DIFF
--- a/docs/dao-operations/dao-roles.md
+++ b/docs/dao-operations/dao-roles.md
@@ -146,7 +146,7 @@ The Steward requests a regular budget where needed to ensure the members are inc
 
 :::info[Latest budget]
 
-~3k per quarter
+~2k per quarter
 
 :::
 


### PR DESCRIPTION
Updated the budget estimate from ~3k to ~2k per quarter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the latest budget estimate for syncing steward auxiliary roles from approximately 3k to 2k per quarter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->